### PR TITLE
Add Hex Map

### DIFF
--- a/HexMap/.gitattributes
+++ b/HexMap/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf

--- a/HexMap/.gitignore
+++ b/HexMap/.gitignore
@@ -1,0 +1,7 @@
+# Godot 4+ specific ignores
+.godot/
+
+# Project specific ignores
+icon.svg
+icon.svg.import
+project.godot

--- a/HexMap/README.md
+++ b/HexMap/README.md
@@ -1,0 +1,4 @@
+This package contains a simple hex tile in [Scenes3d/World.tscn](Scenes3d/World.tscn). By interacting with the placeholder entities around the hex tile, additional hex tiles are placed at that location and the placeholder is removed. In the logs, clicking on a hex tile reveals the position of the selected hex, and clicking on a placeholder tile also reveals the position of the placeholder as it is removed.
+
+Due to the nature of this project, simply copy and pasting may not work.
+Tested in Godot v4.4.1.

--- a/HexMap/Scenes3d/HexPlaceholder.tscn
+++ b/HexMap/Scenes3d/HexPlaceholder.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=4 format=3 uid="uid://c8nlltbsk6ltc"]
+
+[ext_resource type="Script" uid="uid://bksgxjmar55j1" path="res://Scripts/Tiles/hex_placeholder.gd" id="1_bjlie"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_5bdg1"]
+size = Vector3(0.4, 0.4, 0.25)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_5bdg1"]
+
+[node name="HexPlaceholder" type="Area3D"]
+transform = Transform3D(-4.37114e-08, -1, 0, -4.37114e-08, 1.91069e-15, -1, 1, -4.37114e-08, -4.37114e-08, 0, 0, 0)
+script = ExtResource("1_bjlie")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_5bdg1")
+skeleton = NodePath("")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(0.4, 0, 0, 0, 0.4, 0, 0, 0, 0.4, 0, 0, 0)
+shape = SubResource("BoxShape3D_5bdg1")

--- a/HexMap/Scenes3d/HexTile.tscn
+++ b/HexMap/Scenes3d/HexTile.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=5 format=3 uid="uid://7klo5xq62dwq"]
+
+[ext_resource type="Script" uid="uid://ce5ngaun3322w" path="res://Scripts/Tiles/hex_tile.gd" id="1_y3rtd"]
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_5bdg1"]
+height = 0.2
+radius = 1.0
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_bbkrm"]
+top_radius = 1.0
+bottom_radius = 1.0
+height = 0.2
+radial_segments = 6
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_5bdg1"]
+albedo_color = Color(1, 0, 1, 1)
+
+[node name="HexTile" type="Node3D"]
+transform = Transform3D(-4.37114e-08, -1, 0, -4.37114e-08, 1.91069e-15, -1, 1, -4.37114e-08, -4.37114e-08, 0, 0, 0)
+script = ExtResource("1_y3rtd")
+
+[node name="ClickArea" type="Area3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ClickArea"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0)
+shape = SubResource("CylinderShape3D_5bdg1")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0)
+mesh = SubResource("CylinderMesh_bbkrm")
+surface_material_override/0 = SubResource("StandardMaterial3D_5bdg1")

--- a/HexMap/Scenes3d/World.tscn
+++ b/HexMap/Scenes3d/World.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=5 format=3 uid="uid://cakxtjr12k2as"]
+
+[ext_resource type="Script" uid="uid://cp0u04fqykdfq" path="res://Scripts/Systems/world.gd" id="1_83u66"]
+[ext_resource type="Script" uid="uid://43axed7kjc0a" path="res://Scripts/Tiles/hex_spawner.gd" id="2_eid5w"]
+[ext_resource type="PackedScene" uid="uid://7klo5xq62dwq" path="res://Scenes3d/HexTile.tscn" id="3_w5lq7"]
+[ext_resource type="PackedScene" uid="uid://c8nlltbsk6ltc" path="res://Scenes3d/HexPlaceholder.tscn" id="4_p84yo"]
+
+[node name="World" type="Node3D"]
+script = ExtResource("1_83u66")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 5, 10)
+current = true
+
+[node name="HexSpawner" type="Node" parent="."]
+script = ExtResource("2_eid5w")
+hex_tile = ExtResource("3_w5lq7")
+placeholder_tile = ExtResource("4_p84yo")

--- a/HexMap/Scenes3d/hex_spawner.gd.uid
+++ b/HexMap/Scenes3d/hex_spawner.gd.uid
@@ -1,0 +1,1 @@
+uid://43axed7kjc0a

--- a/HexMap/Scripts/Systems/world.gd
+++ b/HexMap/Scripts/Systems/world.gd
@@ -1,0 +1,62 @@
+extends Node3D
+
+## Dictionary to store Vector2i(q, r) → tile instance
+var placed_tiles: Dictionary = {}
+## Dictionary to store Vector2i(q, r) → placeholder tile instance
+var placed_placeholder_tiles: Dictionary = {}
+@onready var tile_scene = preload("res://Scenes3d/HexTile.tscn")
+@onready var tile_placeholder = preload("res://Scenes3d/HexPlaceholder.tscn")
+@onready var spawner = $HexSpawner
+
+
+func _ready():
+	spawn_tile(0, 0)  # Place the first tile in the center
+
+
+## Spawns a hex tile at the given axial coordinates (q, r) and triggers spawning of placeholder
+## tiles around it.
+func spawn_tile(q: int, r: int):
+	var tile = spawner.spawn_tile(q, r)
+	tile.axial_coords = Vector2i(q, r)
+	add_child(tile)
+	placed_tiles[Vector2i(q, r)] = tile
+
+	spawn_surrounding_placeholders(q, r)
+
+
+## Spawns placeholder tiles around a tile at (q, r). Only spawns in adjacent positions that are not
+## already occupied by a tile or another placeholder. Uses axial offsets to determine valid
+## neighbor positions.
+func spawn_surrounding_placeholders(q: int, r: int):
+	for offset in HexUtils.get_ring_offsets():
+		var new_q = q + offset.x
+		var new_r = r + offset.y
+		var coord = Vector2i(new_q, new_r)
+
+		if placed_tiles.has(coord) or placed_placeholder_tiles.has(coord):
+			continue  # Already exists, skip.
+
+		var placeholder = spawner.spawn_placeholder(new_q, new_r)
+		placeholder.connect("placeholder_clicked", Callable(self, "_on_placeholder_clicked"))
+		add_child(placeholder)
+
+		# Track location of placeholder tiles.
+		placed_placeholder_tiles[coord] = placeholder
+
+
+## When a placeholder is clicked, removes the placeholder, spawns a tile on the location, and
+## spawns placeholders surrounding the tile if possible.
+func _on_placeholder_clicked(q: int, r: int):
+	# Remove the clicked placeholder from world.
+	var coord = Vector2i(q, r)
+	print("Removing placeholder at axial position: ", coord, "	|		global position: ", HexUtils.hex_to_world(q, r))
+	var placeholder = placed_placeholder_tiles.get(coord)
+	if placeholder:
+		placeholder.queue_free()
+		placed_placeholder_tiles.erase(coord)
+
+	# Spawn the real tile at the placeholder location.
+	spawn_tile(q, r)
+
+	# Add placeholders around the newly spawned tile.
+	spawn_surrounding_placeholders(q, r)

--- a/HexMap/Scripts/Systems/world.gd.uid
+++ b/HexMap/Scripts/Systems/world.gd.uid
@@ -1,0 +1,1 @@
+uid://cp0u04fqykdfq

--- a/HexMap/Scripts/Tiles/hex_placeholder.gd
+++ b/HexMap/Scripts/Tiles/hex_placeholder.gd
@@ -1,0 +1,19 @@
+extends Area3D
+## HexPlaceholder
+##
+## Represents an empty placeholder where a tile can be spawned.
+## Emits a signal when clicked, forwarding its axial coordinates to a listener (typically `world.gd`).
+##
+## Instantiated by `HexSpawner`, and removed when converted to a real tile.
+
+signal placeholder_clicked(q: int, r: int)
+var axial_coords: Vector2i
+
+
+func _ready():
+	input_event.connect(_on_input_event)
+	
+
+func _on_input_event(_camera, event, _event_position, _normal, _shape_idx):
+	if event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.MOUSE_BUTTON_LEFT:
+		emit_signal("placeholder_clicked", axial_coords.x, axial_coords.y)

--- a/HexMap/Scripts/Tiles/hex_placeholder.gd.uid
+++ b/HexMap/Scripts/Tiles/hex_placeholder.gd.uid
@@ -1,0 +1,1 @@
+uid://bksgxjmar55j1

--- a/HexMap/Scripts/Tiles/hex_spawner.gd
+++ b/HexMap/Scripts/Tiles/hex_spawner.gd
@@ -1,0 +1,31 @@
+class_name HexSpawner
+extends Node
+## HexSpawner
+## 
+## This class handles instantiation of hex tile and placeholder scenes.
+## Provides reusable spawn functions that convert axial coordinates to 3D world positions.
+##
+## Expects scene resources to be assigned via the Inspector or at runtime.
+
+@export var hex_tile: PackedScene
+@export var placeholder_tile: PackedScene
+@export var tile_radius: float = 1.0
+@export var tile_height_offset: float = 0.0  # Optional vertical offset
+
+
+## Instantiates and returns a HexTile scene at the specified axial coordinates.
+## Applies radius and height offset as configured.
+func spawn_tile(q: int, r: int) -> Node3D:
+	var tile = hex_tile.instantiate()
+	tile.position = HexUtils.hex_to_world(q, r, tile_radius) + Vector3(0, tile_height_offset, 0)
+	tile.axial_coords = Vector2i(q, r)
+	return tile
+
+
+## Instantiates and returns a HexPlaceholder scene at the specified axial coordinates.
+## Uses axial-to-world conversion and does not attach the node to the tree.
+func spawn_placeholder(q: int, r: int) -> Area3D:
+	var placeholder = placeholder_tile.instantiate()
+	placeholder.position = HexUtils.hex_to_world(q, r, tile_radius)
+	placeholder.axial_coords = Vector2i(q, r)
+	return placeholder

--- a/HexMap/Scripts/Tiles/hex_spawner.gd.uid
+++ b/HexMap/Scripts/Tiles/hex_spawner.gd.uid
@@ -1,0 +1,1 @@
+uid://43axed7kjc0a

--- a/HexMap/Scripts/Tiles/hex_tile.gd
+++ b/HexMap/Scripts/Tiles/hex_tile.gd
@@ -1,0 +1,23 @@
+extends Node3D
+## HexTile
+##
+## Represents a placed hex tile in the world grid.
+## Handles player interaction (e.g. selection, input) and stores axial grid coordinates.
+##
+## Usually instantiated and added to the scene by `HexSpawner`.
+
+@export var TILE_RADIUS: float = 1.0
+@export var WIDTH: float = TILE_RADIUS * 2
+@export var HEIGHT: float = sqrt(3) * TILE_RADIUS
+var axial_coords: Vector2i
+@onready var area = $ClickArea
+
+
+func _ready():
+	area.input_event.connect(_on_area_input_event)
+
+
+## Does an action if a tile is selected.
+func _on_area_input_event(_camera, event, _position, _normal, _shape_idx):
+	if event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.MOUSE_BUTTON_LEFT:
+		print("HexTile clicked at axial position: ", axial_coords, "		|		global position: ", global_position, " ")

--- a/HexMap/Scripts/Tiles/hex_tile.gd.uid
+++ b/HexMap/Scripts/Tiles/hex_tile.gd.uid
@@ -1,0 +1,1 @@
+uid://ce5ngaun3322w

--- a/HexMap/Scripts/Tiles/hex_utils.gd
+++ b/HexMap/Scripts/Tiles/hex_utils.gd
@@ -1,0 +1,28 @@
+class_name HexUtils
+extends Node
+## HexUtils
+##
+## Static utility class for working with hex coordinate systems.
+## Contains helper functions to convert axial hex coordinates to world positions.
+##
+## This is a pure, logic-only helper with no scene or node responsibilities.
+
+## Convert hex coordinates to world coordinates.
+static func hex_to_world(q: int, r: int, radius: float = 1.0) -> Vector3:
+	var width = radius * 2.0
+	var height = sqrt(3) * radius
+	var x = width * 0.75 * q
+	var z = height * (r + q * 0.5)
+	return Vector3(x, 0, z)
+
+
+## Returns the current tile's offsets.
+static func get_ring_offsets() -> Array[Vector2i]:
+	return [
+		Vector2i(1, 0),
+		Vector2i(1, -1),
+		Vector2i(0, -1),
+		Vector2i(-1, 0),
+		Vector2i(-1, 1),
+		Vector2i(0, 1)
+	]

--- a/HexMap/Scripts/Tiles/hex_utils.gd.uid
+++ b/HexMap/Scripts/Tiles/hex_utils.gd.uid
@@ -1,0 +1,1 @@
+uid://degvh1thpjy0v


### PR DESCRIPTION
Adds a hex map example.

In Godot 4.4, some files have uid that, if excluded, may potential break changes. Therefore when copying files, include the uid files. More information [here](https://godotengine.org/article/uid-changes-coming-to-godot-4-4/).